### PR TITLE
Allow type to be generated on Linux based Puppet Masters

### DIFF
--- a/lib/puppet/provider/reg_acl/regacl.rb
+++ b/lib/puppet/provider/reg_acl/regacl.rb
@@ -4,8 +4,7 @@ begin
   require 'win32/security'
   require 'win32/registry'
 rescue LoadError
-  puts "This does not appear to be a Windows system.  Exiting..."
-  exit
+  puts "This does not appear to be a Windows system.  Provider may not function."
 end
 
 Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowershell) do

--- a/lib/puppet/provider/reg_acl/regacl.rb
+++ b/lib/puppet/provider/reg_acl/regacl.rb
@@ -1,7 +1,12 @@
 require 'puppet/provider/regpowershell'
 require 'json'
-require 'win32/security'
-require 'win32/registry'
+begin
+  require 'win32/security'
+  require 'win32/registry'
+rescue LoadError
+  puts "This does not appear to be a Windows system.  Exiting..."
+  exit
+end
 
 Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowershell) do
   confine :operatingsystem => :windows


### PR DESCRIPTION
This is a fix for: https://github.com/ipcrm/registry_acl/issues/3

So you might be looking at this going -- why in earth would you want to do that?  In my environment I am making use of r10k and as of Puppet 4, there is an extra step to making sure your environments are properly isolated:
https://docs.puppet.com/puppet/latest/environment_isolation.html#enable-environment-isolation-with-r10k

When the types are generated, it tries to handle all of the requires, and the win32 ones fail on Linux.

This somewhat simple tweak allows the types to be properly generated on Linux and 'served from', and still function on Windows.