### PR TITLE
Modified powershell scripts due to permissions issue

### DIFF
--- a/lib/puppet/provider/reg_acl/regacl.rb
+++ b/lib/puppet/provider/reg_acl/regacl.rb
@@ -1,11 +1,7 @@
 require 'puppet/provider/regpowershell'
 require 'json'
-begin
-  require 'win32/security'
-  require 'win32/registry'
-rescue LoadError
-  puts "This does not appear to be a Windows system.  Provider may not function."
-end
+require 'win32/security'
+require 'win32/registry'
 
 Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowershell) do
   confine :operatingsystem => :windows
@@ -85,12 +81,12 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
       return perm.sort.join(', ')
 
     elsif arg.is_a?(String)
-      perm = Integer.new
+      perm = 0
       defined_perms = arg.split(/,/)
       defined_perms.each do |p|
-        pmask = numperms.rassoc(p)
+        pmask = numperms.rassoc(p.strip)
         raise("Invalid permission - #{p}") if  pmask.nil?
-        perm = perm | pmask
+        perm += pmask[0]
       end
       return perm
     else
@@ -209,10 +205,9 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
           tace["InheritanceFlags"]  = get_inherit(v["InheritanceFlags"])
           tace["PropagationFlags"]  = get_propagate(v["PropagationFlags"])
         rescue => ex
-          # Need a notice message here that indicates what went wrong and
-          # that a pre-existing acl is being ignored.
-          Puppet.debug "Exception caught: #{ex.inspect}"
-          Puppet.notice "Pre-existing ACL on: #{target} #{v.inspect} Ignored due to: #{ex.inspect}"
+          # Show a message in the log that there is an ACL with a problem.
+          Puppet.notice "Pre-existing ACL on : #{target} #{v.inspect}  Ignored due to: #{ex.inspect}"
+          Puppet.debug "Exception caught:  #{ex.inspect}"
         else
           newace.push(tace)
         end
@@ -326,7 +321,12 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
       if @resource[:purge].downcase.to_sym == :false
         cmd << <<-ps1.gsub(/^\s+/,"")
           $acesToRemove = $objACL.Access | ?{ $_.IsInherited -eq $false -and $_.IdentityReference -eq '#{get_account_name(p['IdentityReference'])}' }
-          if ($acesToRemove) { $objACL.RemoveAccessRule($acesToRemove) }
+          if ($acesToRemove) {
+            $acesToRemove | ForEach-Object { 
+              $remACE = New-Object System.Security.AccessControl.RegistryAccessRule($_.IdentityReference, $_.RegistryRights, $_.InheritanceFlags, $_.PropagationFlags, $_.AccessControlType)
+              $objACL.RemoveAccessRule($remACE)
+            }
+          }
         ps1
       end
 
@@ -346,7 +346,7 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
     end
 
     cmd << <<-ps1.gsub(/^\s+/, "")
-      Set-ACL '#{@resource[:target]}' $objACL -ErrorAction Stop
+      Set-ACL "#{@resource[:target]}" $objACL -ErrorAction Stop
     ps1
 
     cmd
@@ -360,6 +360,9 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
     if @property_flush[:owner]
       Puppet.debug "Reg_acl: Enter flush, set owner"
       cmd << <<-ps1.gsub(/^\s+/, "")
+        enable-privilege SeTakeOwnershipPrivilege 
+        enable-privilege SeRestorePrivilege
+        enable-privilege SeBackupPrivilege
         Set-RegOwner '#{@resource[:target]}' -Account '#{get_account_name(@resource[:owner])}' -ErrorAction Stop
       ps1
     end
@@ -371,7 +374,7 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
         ps1
       else
         cmd << <<-ps1.gsub(/^\s+/, "")
-          $objACL = get-acl '#{@resource[:target]}' -ErrorAction Stop
+          $objACL = get-acl "#{@resource[:target]}" -ErrorAction Stop
         ps1
       end
       cmd << ace_rule_builder
@@ -381,9 +384,9 @@ Puppet::Type.type(:reg_acl).provide(:regacl, parent: Puppet::Provider::Regpowers
       Puppet.debug "Reg_acl: Enter flush, inherit from parent"
       rule = @property_flush[:inherit_from_parent].downcase.to_sym.eql?(:true) ? '$False,$False' : '$True,$False'
       cmd << <<-ps1.gsub(/^\s+/, "")
-        $t = get-acl '#{@resource[:target]}'
+        $t = get-acl "#{@resource[:target]}"
         $t.SetAccessRuleProtection(#{rule})
-        Set-ACL '#{@resource[:target]}' $t -ErrorAction Stop
+        Set-ACL "#{@resource[:target]}" $t -ErrorAction Stop
       ps1
     end
 

--- a/lib/puppet_x/util/Set-RegOwner.ps1
+++ b/lib/puppet_x/util/Set-RegOwner.ps1
@@ -1,4 +1,87 @@
-﻿Function Set-RegOwner {
+﻿# The enable-privilege function was copied from 
+# https://social.technet.microsoft.com/Forums/windowsserver/en-US/e718a560-2908-4b91-ad42-d392e7f8f1ad/take-ownership-of-a-registry-key-and-change-permissions?forum=winserverpowershell
+# 
+function enable-privilege {
+ param(
+  ## The privilege to adjust. This set is taken from
+  ## http://msdn.microsoft.com/en-us/library/bb530716(VS.85).aspx
+  [ValidateSet(
+   "SeAssignPrimaryTokenPrivilege", "SeAuditPrivilege", "SeBackupPrivilege",
+   "SeChangeNotifyPrivilege", "SeCreateGlobalPrivilege", "SeCreatePagefilePrivilege",
+   "SeCreatePermanentPrivilege", "SeCreateSymbolicLinkPrivilege", "SeCreateTokenPrivilege",
+   "SeDebugPrivilege", "SeEnableDelegationPrivilege", "SeImpersonatePrivilege", "SeIncreaseBasePriorityPrivilege",
+   "SeIncreaseQuotaPrivilege", "SeIncreaseWorkingSetPrivilege", "SeLoadDriverPrivilege",
+   "SeLockMemoryPrivilege", "SeMachineAccountPrivilege", "SeManageVolumePrivilege",
+   "SeProfileSingleProcessPrivilege", "SeRelabelPrivilege", "SeRemoteShutdownPrivilege",
+   "SeRestorePrivilege", "SeSecurityPrivilege", "SeShutdownPrivilege", "SeSyncAgentPrivilege",
+   "SeSystemEnvironmentPrivilege", "SeSystemProfilePrivilege", "SeSystemtimePrivilege",
+   "SeTakeOwnershipPrivilege", "SeTcbPrivilege", "SeTimeZonePrivilege", "SeTrustedCredManAccessPrivilege",
+   "SeUndockPrivilege", "SeUnsolicitedInputPrivilege")]
+  $Privilege,
+  ## The process on which to adjust the privilege. Defaults to the current process.
+  $ProcessId = $pid,
+  ## Switch to disable the privilege, rather than enable it.
+  [Switch] $Disable
+ )
+
+ ## Taken from P/Invoke.NET with minor adjustments.
+ $definition = @'
+ using System;
+ using System.Runtime.InteropServices;
+  
+ public class AdjPriv
+ {
+  [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+  internal static extern bool AdjustTokenPrivileges(IntPtr htok, bool disall,
+   ref TokPriv1Luid newst, int len, IntPtr prev, IntPtr relen);
+  
+  [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+  internal static extern bool OpenProcessToken(IntPtr h, int acc, ref IntPtr phtok);
+  [DllImport("advapi32.dll", SetLastError = true)]
+  internal static extern bool LookupPrivilegeValue(string host, string name, ref long pluid);
+  [StructLayout(LayoutKind.Sequential, Pack = 1)]
+  internal struct TokPriv1Luid
+  {
+   public int Count;
+   public long Luid;
+   public int Attr;
+  }
+  
+  internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+  internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
+  internal const int TOKEN_QUERY = 0x00000008;
+  internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+  public static bool EnablePrivilege(long processHandle, string privilege, bool disable)
+  {
+   bool retVal;
+   TokPriv1Luid tp;
+   IntPtr hproc = new IntPtr(processHandle);
+   IntPtr htok = IntPtr.Zero;
+   retVal = OpenProcessToken(hproc, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref htok);
+   tp.Count = 1;
+   tp.Luid = 0;
+   if(disable)
+   {
+    tp.Attr = SE_PRIVILEGE_DISABLED;
+   }
+   else
+   {
+    tp.Attr = SE_PRIVILEGE_ENABLED;
+   }
+   retVal = LookupPrivilegeValue(null, privilege, ref tp.Luid);
+   retVal = AdjustTokenPrivileges(htok, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero);
+   return retVal;
+  }
+ }
+'@
+
+ $processHandle = (Get-Process -id $ProcessId).Handle
+ $type = Add-Type $definition -PassThru
+ $type[0]::EnablePrivilege($processHandle, $Privilege, $Disable)
+}
+
+
+Function Set-RegOwner {
     <#
         .SYNOPSIS
             Take ownership of a registry key.
@@ -20,7 +103,9 @@
         [Alias('FullName')]
         [string[]]$Path,
         [parameter()]
-        [string]$Account = 'Builtin\Administrators'
+        [string]$Account = 'Builtin\Administrators',
+        ## The process on which to adjust the privilege. Defaults to the current process.
+        $ProcessId = $pid
     )
     Begin {
         #Prevent Confirmation on each Write-Debug command when using -Debug
@@ -28,97 +113,33 @@
             $DebugPreference = 'Continue'
         }
         Try {
-            [void][TokenAdjuster]
-        } Catch {
-            $AdjustTokenPrivileges = @"
-            using System;
-            using System.Runtime.InteropServices;
 
-             public class TokenAdjuster
-             {
-              [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
-              internal static extern bool AdjustTokenPrivileges(IntPtr htok, bool disall,
-              ref TokPriv1Luid newst, int len, IntPtr prev, IntPtr relen);
-              [DllImport("kernel32.dll", ExactSpelling = true)]
-              internal static extern IntPtr GetCurrentProcess();
-              [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
-              internal static extern bool OpenProcessToken(IntPtr h, int acc, ref IntPtr
-              phtok);
-              [DllImport("advapi32.dll", SetLastError = true)]
-              internal static extern bool LookupPrivilegeValue(string host, string name,
-              ref long pluid);
-              [StructLayout(LayoutKind.Sequential, Pack = 1)]
-              internal struct TokPriv1Luid
-              {
-               public int Count;
-               public long Luid;
-               public int Attr;
-              }
-              internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
-              internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
-              internal const int TOKEN_QUERY = 0x00000008;
-              internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
-              public static bool AddPrivilege(string privilege)
-              {
-               try
-               {
-                bool retVal;
-                TokPriv1Luid tp;
-                IntPtr hproc = GetCurrentProcess();
-                IntPtr htok = IntPtr.Zero;
-                retVal = OpenProcessToken(hproc, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref htok);
-                tp.Count = 1;
-                tp.Luid = 0;
-                tp.Attr = SE_PRIVILEGE_ENABLED;
-                retVal = LookupPrivilegeValue(null, privilege, ref tp.Luid);
-                retVal = AdjustTokenPrivileges(htok, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero);
-                return retVal;
-               }
-               catch (Exception ex)
-               {
-                throw ex;
-               }
-              }
-              public static bool RemovePrivilege(string privilege)
-              {
-               try
-               {
-                bool retVal;
-                TokPriv1Luid tp;
-                IntPtr hproc = GetCurrentProcess();
-                IntPtr htok = IntPtr.Zero;
-                retVal = OpenProcessToken(hproc, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref htok);
-                tp.Count = 1;
-                tp.Luid = 0;
-                tp.Attr = SE_PRIVILEGE_DISABLED;
-                retVal = LookupPrivilegeValue(null, privilege, ref tp.Luid);
-                retVal = AdjustTokenPrivileges(htok, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero);
-                return retVal;
-               }
-               catch (Exception ex)
-               {
-                throw ex;
-               }
-              }
-             }
-"@
-            Add-Type $AdjustTokenPrivileges
+        } Catch {
         }
 
-        #Activate necessary admin privileges to make changes without NTFS perms
-        [void][TokenAdjuster]::AddPrivilege("SeRestorePrivilege") #Necessary to set Owner Permissions
-        [void][TokenAdjuster]::AddPrivilege("SeBackupPrivilege") #Necessary to bypass Traverse Checking
-        [void][TokenAdjuster]::AddPrivilege("SeTakeOwnershipPrivilege") #Necessary to override FilePermissions
     }
     Process {
-      $a = Get-ACL $Path
-      $a.SetOwner([System.Security.Principal.NTAccount]"$Account")
-      set-acl $Path $a
+        # The Path param can be split into two, the first part is the registry, the second part is the path
+        $target_path = $Path.split(":")
+        $reg_path = $target_path[1]
+        $reg_class = switch ($target_path[0]) {
+            'HKEY_CLASSES_ROOT' { "ClassesRoot"; break }
+            'HKEY_LOCAL_MACHINE' { "LocalMachine"; break }
+            'HKEY_USERS' { "Users"; break }
+        }
+        $key = [Microsoft.Win32.Registry]::$reg_class.OpenSubKey("$reg_path",[Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree,[System.Security.AccessControl.RegistryRights]::takeownership)
+        # You must get a blank acl for the key b/c you do not currently have access
+        $acl = $key.GetAccessControl([System.Security.AccessControl.AccessControlSections]::None)
+        $me = [System.Security.Principal.NTAccount]"$Account"
+        $acl.SetOwner($me)
+        $key.SetAccessControl($acl)
+        # After you have set owner you need to get the acl with the perms so you can modify it.
+        $acl = $key.GetAccessControl()
+        $rule = New-Object System.Security.AccessControl.RegistryAccessRule ("$Account","FullControl","Allow")
+        $acl.SetAccessRule($rule)
+        $key.SetAccessControl($acl)
+        $key.Close()
     }
     End {
-        #Remove priviledges that had been granted
-        [void][TokenAdjuster]::RemovePrivilege("SeRestorePrivilege")
-        [void][TokenAdjuster]::RemovePrivilege("SeBackupPrivilege")
-        [void][TokenAdjuster]::RemovePrivilege("SeTakeOwnershipPrivilege")
     }
 }


### PR DESCRIPTION
This is a pretty big change in the Powershell scripts.  I can't take credit for the difference, the main changes in the Set-RegOwner script came from a technet post (URL in the comments).  While the original implementation worked great in my lab, for reasons I can't explain it failed with insufficient permissions in my customers environment.  

This request addresses that by changing where in the scripts the security tokens are obtained and by changing the process for setting the owner from using the get-acl and set-acl commandlets to using win32 class methods directly.  This allows things to work as expected both in my lab on an unmolested 2016 installation and in my customers environment.

I really wish I could say why registry_acl wasn't working in my customer environment, but I've not been able to get to the root.

I have also not had the opportunity to test this change against other versions of windows.