### PR TITLE
(#20) Remove win32/security requirement

### DIFF
--- a/lib/puppet/provider/reg_acl/regacl.rb
+++ b/lib/puppet/provider/reg_acl/regacl.rb
@@ -3,7 +3,6 @@
 require 'puppet/provider/regpowershell'
 require 'json'
 begin
-  require 'win32/security'
   require 'win32/registry'
 rescue LoadError
   puts 'This does not appear to be a Windows system.  Provider may not function.'

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -6,7 +6,7 @@ HOSTS:
       - windows
     platform: windows-server-amd64
     box: gusztavvargadr/windows-server
-    box_version: 2102.0.2208
+    box_version: '~> 2102'
     hypervisor: <%= ENV['BEAKER_HYPERVISOR'] || 'vagrant' %>
     vagrant_memsize: 2048
     vagrant_cpus: 2


### PR DESCRIPTION
The requirement for win32/security is no longer needed for any functionality.

also updates the default beaker nodeset to always use the latest Windows 2022 release from gusztavvargadr